### PR TITLE
feat: migrate web search to Tavily with Bing/DDG fallback

### DIFF
--- a/app/utils/ai_tools.py
+++ b/app/utils/ai_tools.py
@@ -687,10 +687,37 @@ def _summarize_with_subagent(content, url, api_key, provider_id, model_id):
         return f'URL: {url}\n内容长度: {len(content)} 字符 (已截断)\n\n---\n{content[:8000]}\n\n[... 摘要生成异常: {str(e)} ...]'
 
 
+def _web_search_tavily(query):
+    """通过 Tavily API 搜索（需设置 TAVILY_API_KEY 环境变量）"""
+    api_key = os.environ.get('TAVILY_API_KEY')
+    if not api_key:
+        return None
+    try:
+        from tavily import TavilyClient
+        client = TavilyClient(api_key=api_key)
+        response = client.search(query=query, max_results=5, search_depth="basic")
+        results = response.get('results', [])
+        if not results:
+            return None
+        lines = [f'搜索关键词: {query}\n']
+        for i, r in enumerate(results, 1):
+            title = r.get('title', '')
+            url = r.get('url', '')
+            content = r.get('content', '')
+            lines.append(f'{i}. [{title}]({url})\n   {content}\n')
+        return '\n'.join(lines)
+    except Exception:
+        return None
+
+
 def _web_search(args, lib_dir, bm, gid, **extra):
     query = args.get('query', '')
     if not query:
         return '搜索查询不能为空', None
+
+    result = _web_search_tavily(query)
+    if result:
+        return result, None
 
     proxy = os.environ.get('HTTPS_PROXY') or os.environ.get('HTTP_PROXY') or os.environ.get('ALL_PROXY')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ lxml==4.9.3
 Pygments==2.17.2
 requests>=2.31.0
 duckduckgo-search>=6.0.0
+tavily-python>=0.5.0
 


### PR DESCRIPTION
## Summary

- Added Tavily as the first-tried search backend in the `_web_search` orchestrator
- Bing scraping and DuckDuckGo remain as sequential fallbacks when Tavily is unavailable
- Tavily is silently skipped if `TAVILY_API_KEY` is not set, preserving existing behavior

## Files Changed

- `app/utils/ai_tools.py` — Added `_web_search_tavily()` helper function; updated `_web_search()` to call Tavily first
- `requirements.txt` — Added `tavily-python>=0.5.0`

## Dependency Changes

- Added `tavily-python>=0.5.0` to `requirements.txt` (existing `duckduckgo-search` retained)

## Environment Variable Changes

- Added optional `TAVILY_API_KEY` — when set, Tavily is used as the primary search provider; when absent, the existing Bing → DDG chain is used unchanged

## Notes for Reviewers

- The Tavily helper uses `search_depth="basic"` (1 credit per query) with `max_results=5` to match existing result count
- All exceptions are caught and return `None`, falling through to existing providers
- No existing functionality is removed or altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration is correct, minimal, and non-breaking. Tavily is properly added as a primary provider with graceful fallback to Bing and DDG when TAVILY_API_KEY is absent. SDK usage is valid, requirements.txt is updated, and no existing functionality is regressed. The only gap is that README documentation still describes Bing as the default without mentioning Tavily or its API key requirement.
