### PR TITLE
Make Dependabot updates reviewable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     groups:
       python-minor-and-patch:
         patterns: ["*"]
@@ -14,7 +14,7 @@ updates:
     directory: /apps/web
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     groups:
       web-minor-and-patch:
         patterns: ["*"]
@@ -24,7 +24,7 @@ updates:
     directory: /packages/api-client
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     groups:
       api-client-minor-and-patch:
         patterns: ["*"]
@@ -34,7 +34,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     groups:
       docker-minor-and-patch:
         patterns: ["*"]
@@ -44,7 +44,7 @@ updates:
     directory: /infra
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     groups:
       compose-minor-and-patch:
         patterns: ["*"]
@@ -54,7 +54,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     groups:
       actions-minor-and-patch:
         patterns: ["*"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ The repository uses semantic versioning for released API and container artifacts
   that frozen lock, and Dependabot updates the native `uv` ecosystem.
 - Dependabot now groups compatible minor and patch updates, limits concurrent
   pull requests per ecosystem, and understands the Compose manifest directly.
+- Dependabot permits only one open pull request per ecosystem, keeping major
+  upgrades queued behind the grouped routine update instead of flooding the
+  repository with parallel branches.
 - CI exposes one stable `CI required` aggregate status so branch rules do not
   need to duplicate the complete job matrix.
 - Removed an unused Web dependency that linked `node_modules` back to the
@@ -78,6 +81,9 @@ The repository uses semantic versioning for released API and container artifacts
   used by CI.
 - Expanded Git ignore rules for package-manager credentials, private keys,
   certificates, keystores, and local secret files.
+- The container supply-chain contract now validates the uv builder's immutable
+  SemVer-plus-digest form without hard-coding one release, so Dependabot can
+  refresh that pinned tool image without weakening the pin.
 - The React application and gateway now provide the sole browser security policy; `script-src` remains self-only and no transitional page assets enter either image.
 - API structured logs now use an explicit metadata allowlist, avoid arbitrary argument interpolation, redact credential-shaped text, and omit exception messages and user payloads.
 - Problem/SSE responses, command journals, backup manifests, and compensation results use stable public errors instead of raw exception text or local paths.

--- a/tests/test_container_supply_chain.py
+++ b/tests/test_container_supply_chain.py
@@ -17,10 +17,12 @@ def test_python_project_build_backend_is_exactly_locked_and_offline() -> None:
         name, version = requirement.split("==", 1)
         assert f'name = "{name}"\nversion = "{version}"' in uv_lock
 
-    assert (
-        "FROM ghcr.io/astral-sh/uv:0.11.15@sha256:"
-        "e590846f4776907b254ac0f44b5b380347af5d90d668138ca7938d1b0c2f98d3 AS uv"
-        in dockerfile
+    assert re.search(
+        r"^FROM ghcr\.io/astral-sh/uv:"
+        r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+        r"@sha256:[0-9a-f]{64} AS uv$",
+        dockerfile,
+        re.MULTILINE,
     )
     assert "COPY --from=uv /uv /usr/local/bin/uv" in dockerfile
     assert "COPY pyproject.toml uv.lock README.md ./" in dockerfile
@@ -99,6 +101,13 @@ def test_web_dependencies_do_not_link_back_to_the_repository_root() -> None:
     assert '"markinote": "file:../.."' not in package
     assert '"markinote": "file:../.."' not in lock
     assert '"node_modules/markinote"' not in lock
+
+
+def test_dependabot_allows_only_one_open_update_per_ecosystem() -> None:
+    dependabot = (REPOSITORY_ROOT / ".github/dependabot.yml").read_text(encoding="utf-8")
+
+    assert dependabot.count("open-pull-requests-limit: 1") == 6
+    assert "open-pull-requests-limit: 3" not in dependabot
 
 
 def test_ci_executes_the_dynamic_docker_context_secret_probe() -> None:


### PR DESCRIPTION
## Summary

- validate the uv builder image by its immutable SemVer-plus-SHA-256 form instead of one hard-coded release
- retain the digest pin while allowing legitimate Dependabot uv image updates to pass repository contracts
- reduce the open PR limit from three to one for each configured ecosystem

## Why

Dependabot PR #24 correctly updated the digest-pinned uv image, but the repository contract still asserted the previous literal version and digest. That made every future automated uv refresh fail even when its image remained immutable.

The initial per-ecosystem limit also allowed more than ten concurrent PRs across six ecosystems. A limit of one keeps routine grouped updates reviewable and queues major upgrades.

## Validation

- container supply-chain contract tests: 8 passed
- Ruff: passed
- Dependabot YAML parsed with six ecosystems, each limited to one open PR
- the uv pin expression accepts both the current image and the digest-pinned form generated in PR #24
- staged paths: 3; docs/runtime data/credential fingerprints: 0